### PR TITLE
Added logging

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -49,6 +49,7 @@ function shell(thisArg: any, f: Function, req: Request, res: Response, args?: an
     req.socket.remoteAddress ||
     ((req.connection as any)['socket'] ? (req.connection as any)['socket'].remoteAddress : null);
   console.log("  ├─── BY: " + ip);
+  console.log("  ├─── AT: " + new Date().toString());
   console.log("  └─── CALLED: " + f.name);
   f.apply(thisArg, args);
 }

--- a/app/app.ts
+++ b/app/app.ts
@@ -9,6 +9,7 @@ import { Request, Response } from "express-serve-static-core";
 import { Express } from "express";
 // import * as handler from "./handler";
 import * as userHandler from "./handlers/userHandler";
+import fs from 'fs';
 
 // Express ---------------------------------------------------------------------
 const express = require('express');
@@ -52,9 +53,21 @@ function shell(thisArg: any, f: Function, req: Request, res: Response, args?: an
   f.apply(thisArg, args);
 }
 
+let getLogs = (dbv: any, reqv: Request, resv: Response) => {
+  fs.readFile('logs.txt', { encoding: null, flag: undefined }, (err: any, data: Buffer) => {
+    if (err) {
+      console.log("\nUnable to retrieve logs!");
+      resv.send("Unable to retrieve logs!");
+    } else {
+      resv.send(data);
+    }
+  });
+};
+
 function main() {
   app.use(express.json());
   app.get('/', (req: Request, res: Response) => shell(undefined, (dbv: any, reqv: Request, resv: Response) => { resv.json({ "test": "up!" }) }, req, res, [db, req, res]));
+  app.get('/logs/', (req: Request, res: Response) => shell(undefined, getLogs, req, res, [db, req, res]));
   app.post('/createUser/', (req: Request, res: Response) => shell(userHandler, userHandler.createUser, req, res, [db, req, res]));
   app.get('/getUser/', (req: Request, res: Response) => shell(userHandler, userHandler.getUser, req, res, [db, req, res]));
   app.delete('/deleteUser/', (req: Request, res: Response) => shell(userHandler, userHandler.deleteUser, req, res, [db, req, res]));

--- a/logs.txt
+++ b/logs.txt
@@ -1,0 +1,21 @@
+Backend running on http://localhost:8080
+
+REQUEST TO: /logs/
+  ├─── BY: ::1
+  └─── CALLED: getLogs
+
+REQUEST TO: /logs/
+  ├─── BY: ::1
+  └─── CALLED: getLogs
+
+REQUEST TO: /logs/
+  ├─── BY: ::1
+  └─── CALLED: getLogs
+
+REQUEST TO: /getUser/
+  ├─── BY: ::1
+  └─── CALLED: getUser
+
+REQUEST TO: /logs/
+  ├─── BY: ::1
+  └─── CALLED: getLogs

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run tsc && node build/test/runTests.js",
     "tsc": "tsc",
-    "start": "ts-node app/app.ts"
+    "start": "ts-node app/app.ts > logs.txt"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Reason for the change:

Give developers a way to access the logs of the heroku machine for debugging, since they can now deploy their apps to heroku.

More info will be provided in #cue-dev for programmers to set up .env file and use the heroku apps to test.

Test Plan
npm test runs and passes, and also runs and passes when ran from heroku bash directly.