### PR TITLE
Added full logging with endpoint, and added eve-pk header now needed to make requests

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -10,6 +10,7 @@ import { Express } from "express";
 // import * as handler from "./handler";
 import * as userHandler from "./handlers/userHandler";
 import fs from 'fs';
+import uuid from "uuid";
 
 // Express ---------------------------------------------------------------------
 const express = require('express');
@@ -42,17 +43,152 @@ updateServiceAccountWithSecrets();
 let db = admin.firestore();
 // -----------------------------------------------------------------------------
 
+let tabSpaceSize = 2;
+let tabStr = "  ";
+
 function shell(thisArg: any, f: Function, req: Request, res: Response, args?: any[]) {
-  console.log("\nREQUEST TO: " + req.url);
+  requestBoxLog("REQUEST TO: " + req.url);
   var ip = req.headers['x-forwarded-for'] ||
     req.connection.remoteAddress ||
     req.socket.remoteAddress ||
     ((req.connection as any)['socket'] ? (req.connection as any)['socket'].remoteAddress : null);
-  console.log("  ├─── BY: " + ip);
-  console.log("  ├─── AT: " + new Date().toString());
-  console.log("  └─── CALLED: " + f.name);
-  f.apply(thisArg, args);
+  console.log(tabStr + "├─── BY: " + ip);
+  console.log(tabStr + "├─── AT: " + new Date().toString());
+  if (req.get('eve-pk') != process.env.EVE_PK) {
+    console.log(tabStr + "├─── STATUS: REJECTED");
+    let eve_pk_json = { "error": "The header \"eve-pk\" was undefined or incorrect. To obtain the pk value, consult a TPM or dev lead." };
+    res.status(401).json(eve_pk_json);
+    return;
+  } else {
+    console.log(tabStr + "├─── STATUS: ACCEPTED");
+    console.log(tabStr + (req.url.toLowerCase() != "/logs/" ? "├" : "└") + "─── CALLED: " + f.name);
+    f.apply(thisArg, args);
+  }
 }
+
+function printOnResponse(req: Request, res: Response, next: any) {
+  // var oldSend = res.send;
+  var oldJSON = res.json;
+
+  // res.send = function (data: any) {
+  //   if (data != undefined && req.url.trim().toLowerCase() != "/logs/") {
+  //     let str: string = JSON.stringify(data, null, 2);
+  //     responseBoxLog(str);
+  //   }
+  //   return oldSend.apply(res, arguments as any);
+  // }
+
+  res.json = function (data: any) {
+    if (data != undefined && req.url.trim().toLowerCase() != "/logs/") {
+      let str: string = JSON.stringify(data, null, 2);
+      responseBoxLog(str);
+    }
+    return oldJSON.apply(res, arguments as any);
+  }
+  next();
+}
+app.use(printOnResponse);
+
+let requestBoxLog = (msg: string) => {
+  let msgFin = "│ " + msg + " │";
+  let msgTop = "┌" + ((msgFinIn: string) => {
+    let str = "";
+    for (let i = 0; i < msgFinIn.length - 2; i++) {
+      str += "─";
+    }
+    return str;
+  })(msgFin) + "┐";
+  let msgBottom = "└" + ((msgFinIn: string) => {
+    let str = "";
+    for (let i = 0; i < msgFinIn.length - 2; i++) {
+      if (i == tabSpaceSize - 1) {
+        str += "┬";
+      } else {
+        str += "─";
+      }
+    }
+    return str;
+  })(msgFin) + "┘";
+  console.log(msgTop);
+  console.log(msgFin);
+  console.log(msgBottom);
+};
+
+let responseBoxLog = (msg: string) => {
+  let maxMsgLen = 60;
+  let msgFin = "";
+  let msgLen = Math.min(msg.length, maxMsgLen);
+  if (msg.length + 4 < maxMsgLen && !msg.includes("\n")) {
+    msgFin = "│ " + msg + ((value: string) => {
+      let concatStr = "";
+      for (let i = 0; i < msgLen - value.length - 4; i++) {
+        concatStr += " ";
+      }
+      return concatStr;
+    })(msg) + " │";
+  } else {
+    let strs = msg.split('\n');
+    if (strs.length <= 1) {
+      strs = [];
+      strs.unshift("RESPONSE OF:");
+      for (let i = 0; i < msg.length; i += maxMsgLen) {
+        strs.push(((msgFinIn: string) => {
+          let str = "│ ";
+          str += msg.substr(i, Math.min(i + maxMsgLen - 4, msgFinIn.length));
+          let fin = " │";
+          return str + fin;
+        })(msg));
+      }
+    } else {
+      strs.unshift("RESPONSE OF:");
+      for (let i = 0; i < strs.length; i++) {
+        let line = strs[i];
+        if (line.length > maxMsgLen - 4) {
+          strs.splice(i, 1, line.substr(0, maxMsgLen - 4), line.substr(maxMsgLen - 4, line.length));
+        }
+        if (i > 50)
+          break
+      }
+      strs.forEach((val: any, ind: number) => {
+        strs[ind] = "│ " + val + ((value: string) => {
+          let concatStr = "";
+          for (let i = 0; i < msgLen - value.length - 4; i++) {
+            concatStr += " ";
+          }
+          return concatStr;
+        })(val) + " │";
+      });
+    }
+    msgFin = strs.reduce((prev: string, curr: string, currInd: number, arr: string[]) => {
+      if (currInd == arr.length - 1) {
+        return prev += curr;
+      } else {
+        return prev += (curr + "\n");
+      }
+    }, "");
+  }
+  let msgTop = "┌" + ((msgFinIn: string) => {
+    let str = "";
+    for (let i = 0; i < msgLen - 2; i++) {
+      if (i == tabSpaceSize - 1) {
+        str += "┴";
+      } else {
+        str += "─";
+      }
+    }
+    return str;
+  })(msg) + "┐";
+  let msgBottom = "└" + ((msgFinIn: string) => {
+    let str = "";
+    for (let i = 0; i < msgLen - 2; i++) {
+      str += "─";
+    }
+    return str;
+  })(msg) + "┘";
+  console.log(msgTop);
+  console.log(msgFin);
+  console.log(msgBottom);
+};
 
 let getLogs = (dbv: any, reqv: Request, resv: Response) => {
   fs.readFile('logs.txt', { encoding: null, flag: undefined }, (err: any, data: Buffer) => {

--- a/logs.txt
+++ b/logs.txt
@@ -1,21 +1,186 @@
 Backend running on http://localhost:8080
-
-REQUEST TO: /logs/
+┌───────────────────────┐
+│ REQUEST TO: /getUser/ │
+└─┬─────────────────────┘
   ├─── BY: ::1
+  ├─── AT: Fri Jan 24 2020 20:43:16 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: ACCEPTED
+  ├─── CALLED: getUser
+┌─┴────────────────────────────────────────────────────────┐
+│ RESPONSE OF:                                             │
+│ {                                                        │
+│   "uuid": "53c492ed-5205-4201-8f1d-40a95bbff8c9",        │
+│   "email": "jaggerbrulato@gmail.com",                    │
+│   "name": "Jagger"                                       │
+│ }                                                        │
+└──────────────────────────────────────────────────────────┘
+┌──────────────────────────┐
+│ REQUEST TO: /deleteUser/ │
+└─┬────────────────────────┘
+  ├─── BY: ::1
+  ├─── AT: Fri Jan 24 2020 20:43:20 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: ACCEPTED
+  ├─── CALLED: deleteUser
+┌─┴─────────────────┐
+│ RESPONSE OF:      │
+│ {                 │
+│   "deleted": true │
+│ }                 │
+└───────────────────┘
+┌───────────────────────┐
+│ REQUEST TO: /getUser/ │
+└─┬─────────────────────┘
+  ├─── BY: ::1
+  ├─── AT: Fri Jan 24 2020 20:43:22 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: ACCEPTED
+  ├─── CALLED: getUser
+┌─┴────────────────────────────────────────────────────────┐
+│ RESPONSE OF:                                             │
+│ {                                                        │
+│   "error": "OrgUser with email: jaggerbrulato@gmail.com  │
+│ not found!"                                              │
+│ }                                                        │
+└──────────────────────────────────────────────────────────┘
+┌──────────────────────────┐
+│ REQUEST TO: /createUser/ │
+└─┬────────────────────────┘
+  ├─── BY: ::1
+  ├─── AT: Fri Jan 24 2020 20:43:25 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: ACCEPTED
+  ├─── CALLED: createUser
+┌─┴────────────────────────────────────────────────────────┐
+│ RESPONSE OF:                                             │
+│ {                                                        │
+│   "name": "Jagger",                                      │
+│   "uuid": "fca4ec46-2739-4710-99e8-90d05bf5b205",        │
+│   "email": "jaggerbrulato@gmail.com"                     │
+│ }                                                        │
+└──────────────────────────────────────────────────────────┘
+┌──────────────────────────┐
+│ REQUEST TO: /createUser/ │
+└─┬────────────────────────┘
+  ├─── BY: ::1
+  ├─── AT: Fri Jan 24 2020 20:43:29 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: REJECTED
+┌─┴────────────────────────────────────────────────────────┐
+│ RESPONSE OF:                                             │
+│ {                                                        │
+│   "error": "The header \"eve-pk\" was undefined or incor │
+│ rect. To obtain the pk value, consult a TPM or dev lead. │
+│ "                                                        │
+│ }                                                        │
+└──────────────────────────────────────────────────────────┘
+┌──────────────────────────┐
+│ REQUEST TO: /createUser/ │
+└─┬────────────────────────┘
+  ├─── BY: ::1
+  ├─── AT: Fri Jan 24 2020 20:43:30 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: REJECTED
+┌─┴────────────────────────────────────────────────────────┐
+│ RESPONSE OF:                                             │
+│ {                                                        │
+│   "error": "The header \"eve-pk\" was undefined or incor │
+│ rect. To obtain the pk value, consult a TPM or dev lead. │
+│ "                                                        │
+│ }                                                        │
+└──────────────────────────────────────────────────────────┘
+┌───────────────────────┐
+│ REQUEST TO: /getUser/ │
+└─┬─────────────────────┘
+  ├─── BY: ::1
+  ├─── AT: Fri Jan 24 2020 20:43:33 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: ACCEPTED
+  ├─── CALLED: getUser
+┌─┴────────────────────────────────────────────────────────┐
+│ RESPONSE OF:                                             │
+│ {                                                        │
+│   "uuid": "fca4ec46-2739-4710-99e8-90d05bf5b205",        │
+│   "email": "jaggerbrulato@gmail.com",                    │
+│   "name": "Jagger"                                       │
+│ }                                                        │
+└──────────────────────────────────────────────────────────┘
+┌──────────────────────────┐
+│ REQUEST TO: /deleteUser/ │
+└─┬────────────────────────┘
+  ├─── BY: ::1
+  ├─── AT: Fri Jan 24 2020 20:43:36 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: ACCEPTED
+  ├─── CALLED: deleteUser
+┌─┴─────────────────┐
+│ RESPONSE OF:      │
+│ {                 │
+│   "deleted": true │
+│ }                 │
+└───────────────────┘
+┌────────────────────┐
+│ REQUEST TO: /logs/ │
+└─┬──────────────────┘
+  ├─── BY: ::1
+  ├─── AT: Fri Jan 24 2020 20:43:38 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: ACCEPTED
   └─── CALLED: getLogs
-
-REQUEST TO: /logs/
+┌─────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ REQUEST TO: /getUser/?Content-Type=application/json&eve-pk=fc37db67-37f2-4dd2-acf8-fe2e5182b223 │
+└─┬───────────────────────────────────────────────────────────────────────────────────────────────┘
   ├─── BY: ::1
-  └─── CALLED: getLogs
-
-REQUEST TO: /logs/
+  ├─── AT: Fri Jan 24 2020 20:45:02 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: ACCEPTED
+  ├─── CALLED: getUser
+┌─┴────────────────────────────────────────────────────────┐
+│ RESPONSE OF:                                             │
+│ {                                                        │
+│   "error": "OrgUser with email: jaggerbrulato@gmail.com  │
+│ not found!"                                              │
+│ }                                                        │
+└──────────────────────────────────────────────────────────┘
+┌───────────────────────┐
+│ REQUEST TO: /getUser/ │
+└─┬─────────────────────┘
   ├─── BY: ::1
-  └─── CALLED: getLogs
-
-REQUEST TO: /getUser/
+  ├─── AT: Fri Jan 24 2020 20:45:22 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: ACCEPTED
+  ├─── CALLED: getUser
+┌─┴────────────────────────────────────────────────────────┐
+│ RESPONSE OF:                                             │
+│ {                                                        │
+│   "error": "OrgUser with email: jaggerbrulato@gmail.com  │
+│ not found!"                                              │
+│ }                                                        │
+└──────────────────────────────────────────────────────────┘
+┌──────────────────────────┐
+│ REQUEST TO: /createUser/ │
+└─┬────────────────────────┘
   ├─── BY: ::1
-  └─── CALLED: getUser
-
-REQUEST TO: /logs/
+  ├─── AT: Fri Jan 24 2020 20:45:32 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: ACCEPTED
+  ├─── CALLED: createUser
+┌─┴────────────────────────────────────────────────────────┐
+│ RESPONSE OF:                                             │
+│ {                                                        │
+│   "name": "Jagger",                                      │
+│   "uuid": "49483aee-1c9f-491a-97c7-55b0846ff553",        │
+│   "email": "jaggerbrulato@gmail.com"                     │
+│ }                                                        │
+└──────────────────────────────────────────────────────────┘
+┌───────────────────────┐
+│ REQUEST TO: /getUser/ │
+└─┬─────────────────────┘
   ├─── BY: ::1
+  ├─── AT: Fri Jan 24 2020 20:45:34 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: ACCEPTED
+  ├─── CALLED: getUser
+┌─┴────────────────────────────────────────────────────────┐
+│ RESPONSE OF:                                             │
+│ {                                                        │
+│   "email": "jaggerbrulato@gmail.com",                    │
+│   "name": "Jagger",                                      │
+│   "uuid": "49483aee-1c9f-491a-97c7-55b0846ff553"         │
+│ }                                                        │
+└──────────────────────────────────────────────────────────┘
+┌────────────────────┐
+│ REQUEST TO: /logs/ │
+└─┬──────────────────┘
+  ├─── BY: ::1
+  ├─── AT: Fri Jan 24 2020 20:45:36 GMT-0500 (Eastern Standard Time)
+  ├─── STATUS: ACCEPTED
   └─── CALLED: getLogs


### PR DESCRIPTION
Reason for the change:

Give developers a way to access the logs of the heroku machine for debugging, since they can now deploy their apps to heroku. Made it much clearer what the endpoint logs are.

Also, now an api key will need to be passed to the backend that matches the value "EVE_PK" in the backend's .env file. This api key is passed in the header 'eve-pk' when a request is made, which validates the request and serves it instead of giving the rejection message.

More info will be provided in #cue-dev for programmers to set up .env file and use the heroku apps to test.

Test Plan
npm test runs and passes, and also runs and passes when ran from heroku bash directly.