### PR TITLE
Materialize now works using promises

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -61,6 +61,12 @@ function shell(thisArg: any, f: Function, req: Request, res: Response, args?: an
       });
     } else {
       Logger.doLog(null, true, thisArg, f, req, res, args);
+      promise.then((val) => {
+        res.status(400).send(val);
+      }).catch((reason) => {
+        let error = { "error": "Promise rejected for: " + reason };
+        res.status(200).json(error);
+      });
     }
   }
 }

--- a/app/handlers/userHandler.ts
+++ b/app/handlers/userHandler.ts
@@ -6,7 +6,7 @@ import { firestore } from "firebase";
 import { Event, Org, OrgUser, StudentUser } from "../types"
 import { EventRequest, CreateUserRequest, GetUserRequest, DeleteUserRequest } from "../requestTypes";
 import { v4 as uuid } from 'uuid';
-import { materializeProm } from "../util/commonOps";
+import { materialize } from "../util/commonOps";
 
 export async function createUser(db: firestore.Firestore, req: Request, res: Response): Promise<any> {
   let request = req.body as CreateUserRequest;
@@ -57,7 +57,7 @@ export async function getUser(db: firestore.Firestore, req: Request, res: Respon
     let orgUserDocRef = db.collection('orgUsers').doc(`${request.email.toLowerCase()}`);
     return orgUserDocRef.get().then(async doc => {
       if (doc.exists) {
-        return materializeProm(doc.data());
+        return materialize(doc.data());
       } else {
         return { error: "OrgUser with email: " + `${request.email.toLowerCase()}` + " not found!" };
       }
@@ -66,7 +66,7 @@ export async function getUser(db: firestore.Firestore, req: Request, res: Respon
     let studentUserDocRef = db.collection('studentUsers').doc(`${request.email.toLowerCase()}`);
     return studentUserDocRef.get().then(async doc => {
       if (doc.exists) {
-        return materializeProm(doc.data());
+        return materialize(doc.data());
       } else {
         return { error: "StudentUser with email: " + `${request.email.toLowerCase()}` + " not found!" };
       }

--- a/app/handlers/userHandler.ts
+++ b/app/handlers/userHandler.ts
@@ -6,7 +6,7 @@ import { firestore } from "firebase";
 import { Event, Org, OrgUser, StudentUser } from "../types"
 import { EventRequest, CreateUserRequest, GetUserRequest, DeleteUserRequest } from "../requestTypes";
 import { v4 as uuid } from 'uuid';
-import { materialize } from "../util/commonOps";
+import { materializeProm } from "../util/commonOps";
 
 export async function createUser(db: firestore.Firestore, req: Request, res: Response): Promise<any> {
   let request = req.body as CreateUserRequest;
@@ -57,7 +57,7 @@ export async function getUser(db: firestore.Firestore, req: Request, res: Respon
     let orgUserDocRef = db.collection('orgUsers').doc(`${request.email.toLowerCase()}`);
     return orgUserDocRef.get().then(async doc => {
       if (doc.exists) {
-        return await materialize(doc.data());
+        return materializeProm(doc.data());
       } else {
         return { error: "OrgUser with email: " + `${request.email.toLowerCase()}` + " not found!" };
       }
@@ -66,7 +66,7 @@ export async function getUser(db: firestore.Firestore, req: Request, res: Respon
     let studentUserDocRef = db.collection('studentUsers').doc(`${request.email.toLowerCase()}`);
     return studentUserDocRef.get().then(async doc => {
       if (doc.exists) {
-        return await materialize(doc.data());
+        return materializeProm(doc.data());
       } else {
         return { error: "StudentUser with email: " + `${request.email.toLowerCase()}` + " not found!" };
       }

--- a/app/logging/logger.ts
+++ b/app/logging/logger.ts
@@ -106,16 +106,18 @@ export let responseBoxLog = (msg: string) => {
   console.log(msgBottom);
 };
 
-export function getLogs(dbv: any, reqv: Request, resv: Response) {
-  fs.readFile('logs.txt', { encoding: null, flag: undefined }, (err: any, data: Buffer) => {
-    if (err) {
-      console.log("\nUnable to retrieve logs!");
-      resv.send("Unable to retrieve logs!");
-    } else {
-      resv.send(data);
-    }
+export function getLogs(dbv: any, reqv: Request, resv: Response) : Promise<any> {
+  return new Promise<any>((resolve, reject) => {
+    fs.readFile('logs.txt', { encoding: null, flag: undefined }, (err: any, data: Buffer) => {
+      if (err) {
+        console.log("\nUnable to retrieve logs!");
+        resolve("Unable to retrieve logs!");
+      } else {
+        resolve(data);
+      }
+    });
   });
-};
+}
 
 export function doLog(returned: any, status: boolean, thisArg: any, f: Function, req: Request, res: Response, args?: any[]) {
   requestBoxLog("REQUEST TO: " + req.url);

--- a/app/test/runTests.ts
+++ b/app/test/runTests.ts
@@ -89,13 +89,20 @@ async function runTest() {
   restrainedLog("│ " + chalk.cyan("Module") + ": " + chalk.yellow(testClassNames[classIndex]));
   restrainedLog("│ " + chalk.cyan("Running test") + ": " + chalk.magenta(currentlyRunningTest.name));
   restrainedLog("│");
-  let promise = currentlyRunningTest.apply(null, [db]);
-  promise.then(async () => {
-    nextTest();
-    if (!testsOver) {
-      await runTest();
-    }
-  });
+  await currentlyRunningTest.apply(null, [db]);
+  nextTest();
+  if (!testsOver) {
+    await runTest();
+  }
+  // let promise = currentlyRunningTest.apply(null, [db]);
+  // return promise.then(async () => {
+  //   nextTest();
+  //   if (!testsOver) {
+  //     return runTest();
+  //   } else {
+  //     return;
+  //   }
+  // });
 }
 
 function nextTest() {

--- a/app/test/tests/commonOpsTest.ts
+++ b/app/test/tests/commonOpsTest.ts
@@ -9,19 +9,19 @@ export async function runMaterializeDepthTest(db: firestore.Firestore) {
   const depth = 7;
   const str = "enoch";
   const mockChain = (str: string) => {
-    let temp: { ref: any } = { ref: str };
+    let temp: { ref: any, another: any } = { ref: str, another: str };
     for (let i = 0; i < depth; i++) {
-      temp = { ref: temp };
+      temp = { ref: temp, another: temp };
     }
     return temp;
   };
 
   let ref = db.collection("test").doc(`materializeDepth0`);
-  await ref.set({ ref: str });
+  await ref.set({ ref: str, another: str });
   for (let i = 1; i <= depth; i++) {
     let temp = ref;
     ref = db.collection("test").doc(`materializeDepth${i}`);
-    await ref.set({ ref: temp });
+    await ref.set({ ref: temp, another: temp });
   }
 
   const res = await ref.get().then(doc => materialize(doc.data(), depth));
@@ -29,8 +29,9 @@ export async function runMaterializeDepthTest(db: firestore.Firestore) {
     .expect(res)
     .is.defined();
 
-  const resJson = JSON.stringify(res);
-  const mockJson = JSON.stringify(mockChain(str));
+  const resJson = JSON.stringify(res, Object.keys(res).sort());
+  let mockChainObj = mockChain(str);
+  const mockJson = JSON.stringify(mockChainObj, Object.keys(mockChainObj).sort());
   describe(`Response should be fully flattened`)
     .expect(resJson)
     .toBe.equalTo(mockJson);

--- a/app/util/commonOps.ts
+++ b/app/util/commonOps.ts
@@ -21,7 +21,7 @@ export async function docRefArrayFromCollectionRef(coll: firestore.CollectionRef
   });
 }
 
-const maxDepthDefault = 10;
+const maxDepthDefault = 5;
 
 /**
  * This function takes in a JS struct, and recursively flattens out all the

--- a/app/util/commonOps.ts
+++ b/app/util/commonOps.ts
@@ -6,71 +6,10 @@ import { isUndefined } from "util";
 /**
  * This function takes a collection reference and turns it into an array
  * of its constituent document references
- * 
+ *
  * @param coll the collection to convert into a docref array
  */
-export async function docRefArrayFromCollectionRef(coll: firestore.CollectionReference) {
-  // Init array
-  let insArr: firestore.DocumentReference[] = [];
-  // Go through each doc and add their reference
-  await coll.get().then(snapshot => {
-    snapshot.forEach(element => {
-      insArr.push(element.ref);
-    })
-  });
-  // Return the array
-  return insArr;
-}
-
-const maxDepthDefault = 5;
-
-/**
- * This function takes in a JS struct, and recursively flattens out all the
- * references into their actual data values.
- * 
- * Essentially, it converts all the references to their values so that the data
- * can be passed in json.
- * 
- * @param object The object to materialize
- * @param depth The maximum depth of materialization (maxDepthDefault = 5)
- */
-export async function materialize(object?: firestore.DocumentData, depth = maxDepthDefault) {
-
-  if (depth <= 0) {
-    return object;
-  }
-
-  let objectStruct = Object.assign({}, object);
-
-  for (let prop in objectStruct) {
-    if (Object.prototype.hasOwnProperty.call(objectStruct, prop)) {
-
-      if (isDocRef(objectStruct[prop])) {
-        let ref = objectStruct[prop] as firestore.DocumentReference;
-        let data = await ref.get().then(val => val.data());
-        objectStruct[prop] = await materialize(data, depth - 1);
-      }
-      else if (objectStruct[prop] instanceof Array && objectStruct[prop].length > 0
-        && isDocRef(objectStruct[prop][0])) {
-        let refArr = objectStruct[prop] as Array<firestore.DocumentReference>;
-        let dataArr = [];
-        for (let i = 0; i < refArr.length; i++) {
-          let ref = refArr[i];
-          let data = await ref.get().then(valRet => valRet.data());
-          dataArr.push(await materialize(data, depth - 1))
-        }
-        objectStruct[prop] = dataArr;
-      }
-      else if (isCollRef(objectStruct[prop])) {
-        let collection = objectStruct[prop] as firestore.CollectionReference;
-        objectStruct[prop] = await materialize(await docRefArrayFromCollectionRef(collection), depth - 1);
-      }
-    }
-  }
-  return objectStruct;
-}
-
-export async function docRefArrayFromCollectionRefProm(coll: firestore.CollectionReference) {
+export async function docRefArrayFromCollectionRef(coll: firestore.CollectionReference) : Promise<Array<any>> {
   // Init array
   let insArr: firestore.DocumentReference[] = [];
   // Go through each doc and add their reference
@@ -82,6 +21,8 @@ export async function docRefArrayFromCollectionRefProm(coll: firestore.Collectio
   });
 }
 
+const maxDepthDefault = 10;
+
 /**
  * This function takes in a JS struct, and recursively flattens out all the
  * references into their actual data values.
@@ -92,7 +33,7 @@ export async function docRefArrayFromCollectionRefProm(coll: firestore.Collectio
  * @param object The object to materialize
  * @param depth The maximum depth of materialization (maxDepthDefault = 5)
  */
-export async function materializeProm(object?: firestore.DocumentData, depth = maxDepthDefault) : Promise<any> {
+export async function materialize(object?: firestore.DocumentData, depth = maxDepthDefault) : Promise<any> {
   return new Promise((res, rej) => {
     if (depth <= 0) {
        res(object);
@@ -109,7 +50,7 @@ export async function materializeProm(object?: firestore.DocumentData, depth = m
         if (isDocRef(objectStruct[prop])) {
           let ref = objectStruct[prop] as firestore.DocumentReference;
           let dataProm = ref.get().then(val => val.data()).then((data) => {
-            return materializeProm(data, depth - 1);
+            return materialize(data, depth - 1);
           });
           propToProm.push([prop, dataProm]);
           foundAProp = true;
@@ -121,7 +62,7 @@ export async function materializeProm(object?: firestore.DocumentData, depth = m
           for (let i = 0; i < refArr.length; i++) {
             let ref = refArr[i];
             let dataProm = ref.get().then(valRet => valRet.data()).then(data => {
-              return materializeProm(data, depth - 1);
+              return materialize(data, depth - 1);
             });
             groupProm.push(dataProm);
           }
@@ -130,8 +71,8 @@ export async function materializeProm(object?: firestore.DocumentData, depth = m
         }
         else if (isCollRef(objectStruct[prop])) {
           let collection = objectStruct[prop] as firestore.CollectionReference;
-          let promRet = docRefArrayFromCollectionRefProm(collection).then(colAsArr => {
-            return materializeProm(colAsArr, depth - 1);
+          let promRet = docRefArrayFromCollectionRef(collection).then(colAsArr => {
+            return materialize(colAsArr, depth - 1);
           });
           propToProm.push([prop, promRet]);
           foundAProp = true;
@@ -147,9 +88,9 @@ export async function materializeProm(object?: firestore.DocumentData, depth = m
 
     return Promise.all(waitForThese).then((values) => {
       for(let i = 0; i < values.length; i++){
-        objectStruct[propToProm[i][0]] = materializeProm(values[i], depth - 1);
+        objectStruct[propToProm[i][0]] = values[i];
       }
-      return objectStruct;
+      res(objectStruct);
     });
   });
 }

--- a/app/util/commonOps.ts
+++ b/app/util/commonOps.ts
@@ -70,6 +70,90 @@ export async function materialize(object?: firestore.DocumentData, depth = maxDe
   return objectStruct;
 }
 
+export async function docRefArrayFromCollectionRefProm(coll: firestore.CollectionReference) {
+  // Init array
+  let insArr: firestore.DocumentReference[] = [];
+  // Go through each doc and add their reference
+  return coll.get().then(snapshot => {
+    snapshot.forEach(element => {
+      insArr.push(element.ref);
+    });
+    return insArr;
+  });
+}
+
+/**
+ * This function takes in a JS struct, and recursively flattens out all the
+ * references into their actual data values.
+ *
+ * Essentially, it converts all the references to their values so that the data
+ * can be passed in json.
+ *
+ * @param object The object to materialize
+ * @param depth The maximum depth of materialization (maxDepthDefault = 5)
+ */
+export async function materializeProm(object?: firestore.DocumentData, depth = maxDepthDefault) : Promise<any> {
+  return new Promise((res, rej) => {
+    if (depth <= 0) {
+       res(object);
+    }
+
+    let objectStruct = Object.assign({}, object);
+
+    let propToProm: [string, Promise<any>][] = [];
+
+    let foundAProp = false;
+
+    for (let prop in objectStruct) {
+      if (Object.prototype.hasOwnProperty.call(objectStruct, prop)) {
+        if (isDocRef(objectStruct[prop])) {
+          let ref = objectStruct[prop] as firestore.DocumentReference;
+          let dataProm = ref.get().then(val => val.data()).then((data) => {
+            return materializeProm(data, depth - 1);
+          });
+          propToProm.push([prop, dataProm]);
+          foundAProp = true;
+        }
+        else if (objectStruct[prop] instanceof Array && objectStruct[prop].length > 0
+            && isDocRef(objectStruct[prop][0])) {
+          let refArr = objectStruct[prop] as Array<firestore.DocumentReference>;
+          let groupProm = [];
+          for (let i = 0; i < refArr.length; i++) {
+            let ref = refArr[i];
+            let dataProm = ref.get().then(valRet => valRet.data()).then(data => {
+              return materializeProm(data, depth - 1);
+            });
+            groupProm.push(dataProm);
+          }
+          propToProm.push([prop, Promise.all(groupProm)]);
+          foundAProp = true;
+        }
+        else if (isCollRef(objectStruct[prop])) {
+          let collection = objectStruct[prop] as firestore.CollectionReference;
+          let promRet = docRefArrayFromCollectionRefProm(collection).then(colAsArr => {
+            return materializeProm(colAsArr, depth - 1);
+          });
+          propToProm.push([prop, promRet]);
+          foundAProp = true;
+        }
+      }
+    }
+
+    if(!foundAProp){
+      res(objectStruct);
+    }
+
+    let waitForThese : Promise<any>[] = propToProm.map(([k, v]) => v);
+
+    return Promise.all(waitForThese).then((values) => {
+      for(let i = 0; i < values.length; i++){
+        objectStruct[propToProm[i][0]] = materializeProm(values[i], depth - 1);
+      }
+      return objectStruct;
+    });
+  });
+}
+
 function isDocRef(val: any) {
   return typeof (val.collection) === 'function'
     && typeof (val.doc) === 'undefined'


### PR DESCRIPTION
Awaiting the materialize function would take very long for deep references, as it works by waiting for firebase promises to return. Instead of this, I have changed materialize to use what is essentially a promise tree, so that all the firebase requests are handled asynchronously, and no endpoint is ever blocking synchronous execution. Once materialize has received all the info, it resolves its original promise. So, returning materialize(whatever) returns a promise, which is good for endpoints because the app already expects a promise to be returned from the endpoints.

I tested this by running npm test, in which the materialize test still passes with deep references and multiple branches from each reference. Looks good.