### PR TITLE
User-related endpoints

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -1,16 +1,12 @@
 // This file is the entry point of the app and also routes the urls to specific
 // handling methods in the handler.
 
-// Read .env file --------------------------------------------------------------
-const dotenv = require('dotenv').config();
-// -----------------------------------------------------------------------------
-
 import { Request, Response } from "express-serve-static-core";
 import { Express } from "express";
 import * as Logger from "./logging/logger";
 // import * as handler from "./handler";
 import * as userHandler from "./handlers/userHandler";
-import uuid from "uuid";
+import { db } from "./util/firebase"
 
 // Express ---------------------------------------------------------------------
 const express = require('express');
@@ -18,57 +14,33 @@ const app: Express = express()
 const port = process.env.PORT || 8080;
 // -----------------------------------------------------------------------------
 
-// Firebase --------------------------------------------------------------------
-let admin = require('firebase-admin');
-let serviceAccount = require('../secrets/eventsbackenddatabase-firebase-adminsdk-ukak2-d1b3a5ef55.json');
-function updateServiceAccountWithSecrets() {
-  serviceAccount["private_key_id"] = process.env.PK_ID ? process.env.PK_ID : "null";
-  if (serviceAccount["private_key_id"] == "null" || !serviceAccount["private_key_id"]) {
-    console.log("ERROR: No PK_ID in .env, pk val is: " + serviceAccount["private_key_id"]);
-    throw new Error("No PK_ID in .env");
-  }
-  serviceAccount["private_key"] = process.env.PK_PWD ? process.env.PK_PWD : "null";
-  if (serviceAccount["private_key"] == "null" || !serviceAccount["private_key"]) {
-    console.log("ERROR: No PK_PWD in .env, pk_pwd val is: " + serviceAccount["private_key"]);
-    throw new Error("No PK_PWD in .env");
-  }
-  // Now init app w/ full service account object
-  admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
-    databaseURL: "https://eventsbackenddatabase.firebaseio.com"
-  });
-}
-updateServiceAccountWithSecrets();
-
-let db = admin.firestore();
-// -----------------------------------------------------------------------------
 
 function shell(thisArg: any, f: Function, req: Request, res: Response, args?: any[]) {
   if (req.get('eve-pk') != process.env.EVE_PK) {
     let eve_pk_json = { "error": "The header \"eve-pk\" was undefined or incorrect. To obtain the pk value, consult a TPM or dev lead." };
     res.status(401).json(eve_pk_json);
     return;
-  } else {
-    let promise: Promise<any> = f.apply(thisArg, args);
-    if (req.url.toLowerCase() !== "/logs/") {
-      promise.then((val) => {
-        Logger.doLog(val, true, thisArg, f, req, res, args);
-        res.status(400).json(val);
-      }).catch((reason) => {
-        let error = { "error": "Promise rejected for: " + reason };
-        Logger.doLog(error, false, thisArg, f, req, res, args);
-        res.status(200).json(error);
-      });
-    } else {
-      Logger.doLog(null, true, thisArg, f, req, res, args);
-      promise.then((val) => {
-        res.status(400).send(val);
-      }).catch((reason) => {
-        let error = { "error": "Promise rejected for: " + reason };
-        res.status(200).json(error);
-      });
-    }
   }
+  let promise: Promise<any> = f.apply(thisArg, args);
+  if (req.url.toLowerCase() !== "/logs/") {
+    promise.then((val) => {
+      Logger.doLog(val, true, thisArg, f, req, res, args);
+      res.status(400).json(val);
+    }).catch((reason) => {
+      let error = { "error": "Promise rejected for: " + reason };
+      Logger.doLog(error, false, thisArg, f, req, res, args);
+      res.status(200).json(error);
+    });
+  } else {
+    Logger.doLog(null, true, thisArg, f, req, res, args);
+    promise.then((val) => {
+      res.status(400).send(val);
+    }).catch((reason) => {
+      let error = { "error": "Promise rejected for: " + reason };
+      res.status(200).json(error);
+    });
+  }
+
 }
 
 function main() {

--- a/app/requestTypes.ts
+++ b/app/requestTypes.ts
@@ -1,19 +1,16 @@
 // Request Types
 
 export type CreateUserRequest = {
-  name: string;
   email: string;
-  isOrgUser: boolean;
+  tags: string[]
 }
 
 export type DeleteUserRequest = {
   email: string;
-  isOrgUser: boolean;
 }
 
 export type GetUserRequest = {
   email: string;
-  isOrgUser: boolean;
 }
 
 export type EventRequest = {

--- a/app/test/tests/userHandlerTest.ts
+++ b/app/test/tests/userHandlerTest.ts
@@ -1,108 +1,138 @@
-import * as userHandler from '../../handlers/userHandler';
-import { firestore } from 'firebase';
-import { describe } from '../testExtensions';
-import * as runTests from '../runTests';
-var MockExpressRequest = require('mock-express-request');
-var MockExpressResponse = require('mock-express-response');
+import * as userHandler from "../../handlers/userHandler";
+import { firestore } from "firebase";
+import { describe } from "../testExtensions";
+import * as runTests from "../runTests";
+import {
+  CreateUserRequest,
+  GetUserRequest,
+  DeleteUserRequest
+} from "../../requestTypes";
 
+var MockExpressRequest = require("mock-express-request");
+var MockExpressResponse = require("mock-express-response");
 
 // Begin Tests -----------------------------------------------------------------
 
 export async function runDeleteTest(db: firestore.Firestore) {
-  let mockRequest = new MockExpressRequest(
-    {
-      method: 'POST',
-      url: '/deleteUser/',
-      body: {
-        email: "jaggerbrulato@gmail.com",
-        isOrgUser: true
-      }
-    }
-  );
+  let mockBody: DeleteUserRequest = {
+    email: "sirenochen@gmail.com"
+  };
+  let mockRequest = new MockExpressRequest({
+    method: "POST",
+    url: "/deleteUser/",
+    body: mockBody
+  });
   let mockResponse = new MockExpressResponse();
-  let preDoc = db.collection('orgUsers').doc("jaggerbrulato@gmail.com");
-  await preDoc.get().then(async (snap) => {
-      if(snap.exists){
-          return;
-      }
-      await preDoc.set({
-          email: "jaggerbrulato@gmail.com",
-          name: "Jagger",
-          uuid: "800ff79a-dee3-4926-8768-4101dae2007d"
-      });
+  let preDoc = db.collection("users").doc("sirenochen@gmail.com");
+  await preDoc.get().then(async snap => {
+    if (snap.exists) {
+      return;
+    }
+    await preDoc.set({
+      tags: ["freefood", "positivity"]
+    });
   });
   // Simulate the app's sending of handler output to response
-  mockResponse.json(await userHandler.deleteUser(db, mockRequest, mockResponse));
+  mockResponse.json(
+    await userHandler.deleteUser(db, mockRequest, mockResponse)
+  );
   let docExists;
-  await db.collection('orgUsers').doc(mockRequest.body.email).get().then(doc => {
-    docExists = doc.exists;
-  });
-  describe("User deleted returned true").expect(mockResponse._getJSON().deleted).toBe.equalTo(true);
-  describe("Expect doc not to exist").expect(docExists).toBe.equalTo(false);
+  await db
+    .collection("orgUsers")
+    .doc(mockRequest.body.email)
+    .get()
+    .then(doc => {
+      docExists = doc.exists;
+    });
+  describe("User deleted returned true")
+    .expect(mockResponse._getJSON().deleted)
+    .toBe.equalTo(true);
+  describe("Expect doc not to exist")
+    .expect(docExists)
+    .toBe.equalTo(false);
 }
 
 export async function runCreateTest(db: firestore.Firestore) {
-  let mockRequest = new MockExpressRequest(
-    {
-      method: 'POST',
-      url: '/createUser/',
-      body: {
-        name: "Jagger",
-        email: "jaggerbrulato@gmail.com",
-        isOrgUser: true
-      }
-    }
-  );
+  let mockBody: CreateUserRequest = {
+    email: "sirenochen@gmail.com",
+    tags: ["freefood", "positivity"]
+  };
+  let mockRequest = new MockExpressRequest({
+    method: "POST",
+    url: "/createUser/",
+    body: mockBody
+  });
   let mockResponse = new MockExpressResponse();
-  let preDoc = db.collection('orgUsers').doc("jaggerbrulato@gmail.com");
-  await preDoc.get().then(async (snap) => {
-      if(snap.exists){
-          await snap.ref.delete();
-          return;
-      }
+  let preDoc = db.collection("users").doc("sirenochen@gmail.com");
+  await preDoc.get().then(async snap => {
+    if (snap.exists) {
+      await snap.ref.delete();
+      return;
+    }
   });
   // Simulate the app's sending of handler output to response
-  mockResponse.json(await userHandler.createUser(db, mockRequest, mockResponse));
-  let orgUserResp: any;
-  await db.collection('orgUsers').doc("jaggerbrulato@gmail.com").get()
+  mockResponse.json(
+    await userHandler.createUser(db, mockRequest, mockResponse)
+  );
+  
+  // Check actual Firebase data
+  let userResult = await db
+    .collection("users")
+    .doc("sirenochen@gmail.com")
+    .get()
     .then(doc => {
-      orgUserResp = doc.data();
+      describe("Expect user sirenochen@gmail.com doc to exist")
+        .expect(doc.exists)
+        .toBe.equalTo(true);
+      return doc.data();
     });
-  describe("Orguser name should be Jagger").expect(orgUserResp.name).toBe.equalTo("Jagger");
-  describe("Orguser email should be jaggerbrulato@gmail.com").expect(orgUserResp.email).toBe.equalTo("jaggerbrulato@gmail.com");
+  describe("User tags should be correct")
+    .expect(userResult?.tags)
+    .is.defined();
 }
 
 export async function runGetTest(db: firestore.Firestore) {
-  let mockRequest = new MockExpressRequest(
-    {
-      method: 'GET',
-      url: '/getUser/',
-      body: {
-        email: "jaggerbrulato@gmail.com",
-        isOrgUser: true
-      }
-    }
-  );
-  let mockResponse = new MockExpressResponse();
-  let preDoc = db.collection('orgUsers').doc("jaggerbrulato@gmail.com");
-  await preDoc.get().then(async (snap) => {
-      if(snap.exists){
-          return;
-      }
-      await preDoc.set({
-          email: "jaggerbrulato@gmail.com",
-          name: "Jagger",
-          uuid: "800ff79a-dee3-4926-8768-4101dae2007d"
-      });
+  let mockBody: GetUserRequest = {
+    email: "sirenochen@gmail.com"
+  };
+  let mockRequest = new MockExpressRequest({
+    method: "GET",
+    url: "/getUser/",
+    body: mockBody
   });
-  // Simulate the app's sending of handler output to resposne
-  mockResponse.json(await userHandler.getUser(db, mockRequest, mockResponse));
-  let orgUserResp: any;
-  await db.collection('orgUsers').doc("jaggerbrulato@gmail.com").get()
-    .then(doc => {
-      describe("Expect orguser jaggerbrulato@gmail.com doc to exist").expect(doc.exists).toBe.equalTo(true);
-      orgUserResp = doc.data();
+  let mockResponse = new MockExpressResponse();
+  let preDoc = db.collection("users").doc("sirenochen@gmail.com");
+  await preDoc.get().then(async snap => {
+    if (snap.exists) {
+      return;
+    }
+    await preDoc.set({
+      tags: ["freefood", "positivity"]
     });
-  describe("Expect OrgUser name to be defined").expect(orgUserResp.name).is.defined();
-  describe("Orguser email should be jaggerbrulato@gmail.com").expect(orgUserResp.email).toBe.equalTo("jaggerbrulato@gmail.com");
+  });
+
+  // Simulate the app's sending of handler output to response
+  mockResponse.json(await userHandler.getUser(db, mockRequest, mockResponse));
+  let mockResult = mockResponse._getJSON();
+  describe("User displayName should be defined")
+    .expect(mockResult.displayName)
+    .is.defined();
+  describe("User email should be sirenochen@gmail.com")
+    .expect(mockResult.email)
+    .toBe.equalTo("sirenochen@gmail.com");
+  
+  // Check actual Firebase data
+  let userResult = await db
+    .collection("users")
+    .doc("sirenochen@gmail.com")
+    .get()
+    .then(doc => {
+      describe("Expect user sirenochen@gmail.com doc to exist")
+        .expect(doc.exists)
+        .toBe.equalTo(true);
+      return doc.data();
+    });
+  describe("User tags should be correct")
+    .expect(userResult?.tags)
+    .is.defined();
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -3,28 +3,24 @@
 import { firestore } from "firebase";
 
 export type Event = {
-
   uuid: string;
   name: string;
   description: string;
   startDate: Date;
   endDate: Date;
   organizer: firestore.DocumentReference;
-  location: firestore.DocumentReference;
-  tags: firestore.DocumentReference[];
+  location: Location;
+  tags: string[];
   media: firestore.DocumentReference[];
-
 }
 
 export type Org = {
-
   uuid: string;
   name: string;
   bio: string;
   website: string;
   email: string;
   orgUser: firestore.DocumentReference;
-
 }
 
 export type Location = {
@@ -33,24 +29,11 @@ export type Location = {
   building: string;
 }
 
-export type Tag = {
-  uuid: string;
-  name: string;
-}
-
 export type Media = {
   link: string;
   uploader: firestore.DocumentReference;
 }
 
-export type OrgUser = {
-  uuid: string;
-  name: string;
-  email: string;
-}
-
-export type StudentUser = {
-  uuid: string;
-  name: string;
-  email: string;
+export type UserInfo = {
+  tags: string[];
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -3,35 +3,28 @@
 import { firestore } from "firebase";
 
 export type Event = {
-  uuid: string;
   name: string;
   description: string;
   startDate: Date;
   endDate: Date;
+  numAttendees: number;
   organizer: firestore.DocumentReference;
-  location: Location;
+  location: {
+    room: string;
+    place_id: string;
+    building: string;
+  }
   tags: string[];
-  media: firestore.DocumentReference[];
+  media: string;
 }
 
 export type Org = {
-  uuid: string;
   name: string;
   bio: string;
   website: string;
   email: string;
+  media: string;
   orgUser: firestore.DocumentReference;
-}
-
-export type Location = {
-  room: string;
-  place_id: string;
-  building: string;
-}
-
-export type Media = {
-  link: string;
-  uploader: firestore.DocumentReference;
 }
 
 export type UserInfo = {

--- a/app/util/firebase.ts
+++ b/app/util/firebase.ts
@@ -1,0 +1,30 @@
+import * as admin from 'firebase-admin'
+import dotenv from 'dotenv'
+
+// Read .env file
+dotenv.config();
+
+let serviceAccount = require('../../secrets/eventsbackenddatabase-firebase-adminsdk-ukak2-d1b3a5ef55.json');
+function updateServiceAccountWithSecrets() {
+  serviceAccount["private_key_id"] = process.env.PK_ID ? process.env.PK_ID : "null";
+  if (serviceAccount["private_key_id"] == "null" || !serviceAccount["private_key_id"]) {
+    console.log("ERROR: No PK_ID in .env, pk val is: " + serviceAccount["private_key_id"]);
+    throw new Error("No PK_ID in .env");
+  }
+  serviceAccount["private_key"] = process.env.PK_PWD ? process.env.PK_PWD : "null";
+  if (serviceAccount["private_key"] == "null" || !serviceAccount["private_key"]) {
+    console.log("ERROR: No PK_PWD in .env, pk_pwd val is: " + serviceAccount["private_key"]);
+    throw new Error("No PK_PWD in .env");
+  }
+  // Now init app w/ full service account object
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount),
+    databaseURL: "https://eventsbackenddatabase.firebaseio.com"
+  });
+}
+updateServiceAccountWithSecrets();
+
+let db = admin.firestore();
+let auth = admin.auth();
+
+export { db, auth }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -56,6 +56,7 @@
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     /* Advanced Options */
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
### Summary

Add user-related endpoints that take advantage of firebase's authentication system.

This means that we don't explicitly store information like the user's name in firestore. Information like that can be accessed through the firebase auth system instead, for example with `auth.getUserByEmail(email)`

This also moves firebase-related code into a module in `/utils/firebase`.

### Test Plan

I wrote passing tests for each endpoint.