### PR TITLE
Http status fix

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -53,19 +53,19 @@ function shell(thisArg: any, f: Function, req: Request, res: Response, args?: an
     if (req.url.toLowerCase() !== "/logs/") {
       promise.then((val) => {
         Logger.doLog(val, true, thisArg, f, req, res, args);
-        res.status(400).json(val);
+        res.status(200).json(val);
       }).catch((reason) => {
         let error = { "error": "Promise rejected for: " + reason };
         Logger.doLog(error, false, thisArg, f, req, res, args);
-        res.status(200).json(error);
+        res.status(400).json(error);
       });
     } else {
       Logger.doLog(null, true, thisArg, f, req, res, args);
       promise.then((val) => {
-        res.status(400).send(val);
+        res.status(200).send(val);
       }).catch((reason) => {
         let error = { "error": "Promise rejected for: " + reason };
-        res.status(200).json(error);
+        res.status(400).json(error);
       });
     }
   }


### PR DESCRIPTION
### Summary

A good request should get the response code 200 (Success) instead of code 400 (Bad Request).
Same for bad requests -- they should have a '400' response instead of '200'.

This makes it so it be like that.

### Testing

I made a good request in Postman and status 200 was returned

![image](https://user-images.githubusercontent.com/3837473/79672888-bf752800-81a3-11ea-8353-b1996dfb069d.png)
