### PR TITLE
Auth middleware

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -7,58 +7,106 @@ import * as Logger from "./logging/logger";
 // import * as handler from "./handler";
 import * as userHandler from "./handlers/userHandler";
 import * as orgHandler from "./handlers/orgHandler";
-import { db } from "./util/firebase"
+import { db } from "./util/firebase";
 import { authenticate } from "./auth";
 
 // Express ---------------------------------------------------------------------
-const express = require('express');
-const app: Express = express()
+const express = require("express");
+const app: Express = express();
 const port = process.env.PORT || 8080;
 // -----------------------------------------------------------------------------
 
-
-function shell(thisArg: any, f: Function, req: Request, res: Response, args?: any[]) {
-  if (req.get('eve-pk') != process.env.EVE_PK) {
-    let eve_pk_json = { "error": "The header \"eve-pk\" was undefined or incorrect. To obtain the pk value, consult a TPM or dev lead." };
+const shell = async (
+  thisArg: any,
+  f: Function,
+  checkAuth: boolean,
+  req: Request,
+  res: Response,
+  args?: any[]
+) => {
+  if (req.get("eve-pk") != process.env.EVE_PK) {
+    let eve_pk_json = {
+      error:
+        'The header "eve-pk" was undefined or incorrect. To obtain the pk value, consult a TPM or dev lead.',
+    };
     res.status(401).json(eve_pk_json);
     return;
   }
+  if (checkAuth) {
+    try {
+      [req, res] = await authenticate(req, res);
+    } catch (e) {
+      let error = { error: `Authentication error: ${e}` }
+      res.status(400).json(error);
+      return;
+    }
+  }
   let promise: Promise<any> = f.apply(thisArg, args);
   if (req.url.toLowerCase() !== "/logs/") {
-    promise.then((val) => {
-      Logger.doLog(val, true, thisArg, f, req, res, args);
-      res.status(200).json(val);
-    }).catch((reason) => {
-      let error = { "error": "Promise rejected for: " + reason };
-      Logger.doLog(error, false, thisArg, f, req, res, args);
-      res.status(400).json(error);
-    });
+    promise
+      .then((val) => {
+        Logger.doLog(val, true, thisArg, f, req, res, args);
+        res.status(200).json(val);
+      })
+      .catch((reason) => {
+        let error = { error: "Promise rejected for: " + reason };
+        Logger.doLog(error, false, thisArg, f, req, res, args);
+        res.status(400).json(error);
+      });
   } else {
     Logger.doLog(null, true, thisArg, f, req, res, args);
-    promise.then((val) => {
-      res.status(200).send(val);
-    }).catch((reason) => {
-      let error = { "error": "Promise rejected for: " + reason };
-      res.status(400).json(error);
-    });
+    promise
+      .then((val) => {
+        res.status(200).send(val);
+      })
+      .catch((reason) => {
+        let error = { error: "Promise rejected for: " + reason };
+        res.status(400).json(error);
+      });
   }
-}
+};
 
 function main() {
   app.use(express.json());
-  app.get('/', (req, res) => shell(undefined, (dbv: any, reqv: Request, resv: Response) => { resv.json({ "test": "up!" }) }, req, res, [db, req, res]));
-  app.get('/logs/', (req, res) => shell(Logger, Logger.getLogs, req, res, [db, req, res]));
+  app.get("/", (req, res) =>
+    shell(
+      undefined,
+      (dbv: any, reqv: Request, resv: Response) => {
+        resv.json({ test: "up!" });
+      },
+      false,
+      req,
+      res,
+      [db, req, res]
+    )
+  );
+  app.get("/logs/", (req, res) =>
+    shell(Logger, Logger.getLogs, false, req, res, [db, req, res])
+  );
 
-  app.post('/createUser/', (req, res) => shell(userHandler, userHandler.createUser, req, res, [db, req, res]));
-  app.get('/getUser/', (req, res) => shell(userHandler, userHandler.getUser, req, res, [db, req, res]));
-  app.delete('/deleteUser/', (req, res) => shell(userHandler, userHandler.deleteUser, req, res, [db, req, res]));
+  app.post("/createUser/", (req, res) =>
+    shell(userHandler, userHandler.createUser, true, req, res, [db, req, res])
+  );
+  app.get("/getUser/", (req, res) =>
+    shell(userHandler, userHandler.getUser, false, req, res, [db, req, res])
+  );
+  app.delete("/deleteUser/", (req, res) =>
+    shell(userHandler, userHandler.deleteUser, false, req, res, [db, req, res])
+  );
 
-  app.post('/createOrg/', (req, res) => shell(orgHandler, orgHandler.createOrg, req, res, [db, req, res]));
-  app.get('/getOrg/', (req, res) => shell(orgHandler, orgHandler.getOrg, req, res, [db, req, res]));
-  app.post('/updateOrg/:orgID', (req, res) => shell(orgHandler, orgHandler.updateOrg, req, res, [db, req, res]));
+  app.post("/createOrg/", (req, res) =>
+    shell(orgHandler, orgHandler.createOrg, false, req, res, [db, req, res])
+  );
+  app.get("/getOrg/", (req, res) =>
+    shell(orgHandler, orgHandler.getOrg, false, req, res, [db, req, res])
+  );
+  app.post("/updateOrg/:orgID", (req, res) =>
+    shell(orgHandler, orgHandler.updateOrg, false, req, res, [db, req, res])
+  );
 
-  app.listen(port, () => console.log(`Backend running on http://localhost:${port}`))
+  app.listen(port, () =>
+    console.log(`Backend running on http://localhost:${port}`)
+  );
 }
 
 main();
-

--- a/app/app.ts
+++ b/app/app.ts
@@ -8,6 +8,7 @@ import * as Logger from "./logging/logger";
 import * as userHandler from "./handlers/userHandler";
 import * as orgHandler from "./handlers/orgHandler";
 import { db } from "./util/firebase"
+import { authenticate } from "./auth";
 
 // Express ---------------------------------------------------------------------
 const express = require('express');

--- a/app/app.ts
+++ b/app/app.ts
@@ -41,23 +41,23 @@ function shell(thisArg: any, f: Function, req: Request, res: Response, args?: an
       res.status(200).json(error);
     });
   }
-
 }
 
 function main() {
   app.use(express.json());
-  app.get('/', (req: Request, res: Response) => shell(undefined, (dbv: any, reqv: Request, resv: Response) => { resv.json({ "test": "up!" }) }, req, res, [db, req, res]));
-  app.get('/logs/', (req: Request, res: Response) => shell(Logger, Logger.getLogs, req, res, [db, req, res]));
+  app.get('/', (req, res) => shell(undefined, (dbv: any, reqv: Request, resv: Response) => { resv.json({ "test": "up!" }) }, req, res, [db, req, res]));
+  app.get('/logs/', (req, res) => shell(Logger, Logger.getLogs, req, res, [db, req, res]));
 
-  app.post('/createUser/', (req: Request, res: Response) => shell(userHandler, userHandler.createUser, req, res, [db, req, res]));
-  app.get('/getUser/', (req: Request, res: Response) => shell(userHandler, userHandler.getUser, req, res, [db, req, res]));
-  app.delete('/deleteUser/', (req: Request, res: Response) => shell(userHandler, userHandler.deleteUser, req, res, [db, req, res]));
+  app.post('/createUser/', (req, res) => shell(userHandler, userHandler.createUser, req, res, [db, req, res]));
+  app.get('/getUser/', (req, res) => shell(userHandler, userHandler.getUser, req, res, [db, req, res]));
+  app.delete('/deleteUser/', (req, res) => shell(userHandler, userHandler.deleteUser, req, res, [db, req, res]));
 
-  app.post('/createOrg/', (req: Request, res: Response) => shell(userHandler, orgHandler.createOrg, req, res, [db, req, res]));
-  app.get('/getOrg/', (req: Request, res: Response) => shell(userHandler, orgHandler.getOrg, req, res, [db, req, res]));
-  app.post('/updateOrg/:orgID', (req: Request, res: Response) => shell(userHandler, orgHandler.updateOrg, req, res, [db, req, res]));
+  app.post('/createOrg/', (req, res) => shell(orgHandler, orgHandler.createOrg, req, res, [db, req, res]));
+  app.get('/getOrg/', (req, res) => shell(orgHandler, orgHandler.getOrg, req, res, [db, req, res]));
+  app.post('/updateOrg/:orgID', (req, res) => shell(orgHandler, orgHandler.updateOrg, req, res, [db, req, res]));
 
   app.listen(port, () => console.log(`Backend running on http://localhost:${port}`))
 }
+
 main();
 

--- a/app/app.ts
+++ b/app/app.ts
@@ -6,6 +6,7 @@ import { Express } from "express";
 import * as Logger from "./logging/logger";
 // import * as handler from "./handler";
 import * as userHandler from "./handlers/userHandler";
+import * as orgHandler from "./handlers/orgHandler";
 import { db } from "./util/firebase"
 
 // Express ---------------------------------------------------------------------
@@ -47,9 +48,14 @@ function main() {
   app.use(express.json());
   app.get('/', (req: Request, res: Response) => shell(undefined, (dbv: any, reqv: Request, resv: Response) => { resv.json({ "test": "up!" }) }, req, res, [db, req, res]));
   app.get('/logs/', (req: Request, res: Response) => shell(Logger, Logger.getLogs, req, res, [db, req, res]));
+
   app.post('/createUser/', (req: Request, res: Response) => shell(userHandler, userHandler.createUser, req, res, [db, req, res]));
   app.get('/getUser/', (req: Request, res: Response) => shell(userHandler, userHandler.getUser, req, res, [db, req, res]));
   app.delete('/deleteUser/', (req: Request, res: Response) => shell(userHandler, userHandler.deleteUser, req, res, [db, req, res]));
+
+  app.post('/createOrg/', (req: Request, res: Response) => shell(userHandler, orgHandler.createOrg, req, res, [db, req, res]));
+  app.get('/getOrg/', (req: Request, res: Response) => shell(userHandler, orgHandler.getOrg, req, res, [db, req, res]));
+  app.post('/updateOrg/:orgID', (req: Request, res: Response) => shell(userHandler, orgHandler.updateOrg, req, res, [db, req, res]));
 
   app.listen(port, () => console.log(`Backend running on http://localhost:${port}`))
 }

--- a/app/app.ts
+++ b/app/app.ts
@@ -36,26 +36,22 @@ const shell = async (
   [req, res] = await authenticate(req, res);
   let promise: Promise<any> = f.apply(thisArg, args);
   if (req.url.toLowerCase() !== "/logs/") {
-    promise
-      .then((val) => {
-        Logger.doLog(val, true, thisArg, f, req, res, args);
-        res.status(200).json(val);
-      })
-      .catch((reason) => {
-        let error = { error: "Promise rejected for: " + reason };
-        Logger.doLog(error, false, thisArg, f, req, res, args);
-        res.status(400).json(error);
-      });
+    promise.then((val) => {
+      Logger.doLog(val, true, thisArg, f, req, res, args);
+      res.status(200).json(val);
+    }).catch((reason) => {
+      let error = { error: "Promise rejected for: " + reason };
+      Logger.doLog(error, false, thisArg, f, req, res, args);
+      res.status(400).json(error);
+    });
   } else {
     Logger.doLog(null, true, thisArg, f, req, res, args);
-    promise
-      .then((val) => {
-        res.status(200).send(val);
-      })
-      .catch((reason) => {
-        let error = { error: "Promise rejected for: " + reason };
-        res.status(400).json(error);
-      });
+    promise.then((val) => {
+      res.status(200).send(val);
+    }).catch((reason) => {
+      let error = { "error": "Promise rejected for: " + reason };
+      res.status(400).json(error);
+    });
   }
 }
 
@@ -83,9 +79,7 @@ function main() {
     shell(orgHandler, orgHandler.updateOrg, false, req, res, [db, req, res])
   );
 
-  app.listen(port, () =>
-    console.log(`Backend running on http://localhost:${port}`)
-  );
+  app.listen(port, () => console.log(`Backend running on http://localhost:${port}`));
 }
 
 main();

--- a/app/app.ts
+++ b/app/app.ts
@@ -32,15 +32,7 @@ const shell = async (
     res.status(401).json(eve_pk_json);
     return;
   }
-  if (checkAuth) {
-    try {
-      [req, res] = await authenticate(req, res);
-    } catch (e) {
-      let error = { error: `Authentication error: ${e}` }
-      res.status(400).json(error);
-      return;
-    }
-  }
+  [req, res] = await authenticate(req, res);
   let promise: Promise<any> = f.apply(thisArg, args);
   if (req.url.toLowerCase() !== "/logs/") {
     promise
@@ -91,7 +83,7 @@ function main() {
     shell(userHandler, userHandler.getUser, false, req, res, [db, req, res])
   );
   app.delete("/deleteUser/", (req, res) =>
-    shell(userHandler, userHandler.deleteUser, false, req, res, [db, req, res])
+    shell(userHandler, userHandler.deleteUser, true, req, res, [db, req, res])
   );
 
   app.post("/createOrg/", (req, res) =>

--- a/app/auth.ts
+++ b/app/auth.ts
@@ -6,11 +6,11 @@ export const authenticate = async (
   res: Response
 ): Promise<[Request, Response]> => {
   const header = req.get("Authentication");
-  if (!header) throw "invalid header";
-
-  const [authType, authToken] = header.split(" ");
-  if (authType !== "Bearer") throw "invalid auth type";
-
-  req.authInfo = await auth.verifyIdToken(authToken);
+  if (header) {
+    const [authType, authToken] = header.split(" ");
+    if (authType === "Bearer") {
+      req.authInfo = await auth.verifyIdToken(authToken);
+    }
+  }
   return [req, res];
 };

--- a/app/auth.ts
+++ b/app/auth.ts
@@ -1,20 +1,16 @@
+import { Request, Response } from "express-serve-static-core";
 import { auth } from "./util/firebase";
 
 export const authenticate = async (
   req: Request,
-  res: Response,
-  next: Function
-) => {
-  try {
-    const header = req.headers.get("Authentication");
-    if (!header) throw "invalid header";
+  res: Response
+): Promise<[Request, Response]> => {
+  const header = req.get("Authentication");
+  if (!header) throw "invalid header";
 
-    const [authType, authToken] = header.split(" ");
-    if (authType !== "Bearer") throw "invalid auth type";
+  const [authType, authToken] = header.split(" ");
+  if (authType !== "Bearer") throw "invalid auth type";
 
-    req.authInfo = await auth.verifyIdToken(authToken);
-    next();
-  } catch (e) {
-    return { error: "Not Authorized" };
-  }
+  req.authInfo = await auth.verifyIdToken(authToken);
+  return [req, res];
 };

--- a/app/auth.ts
+++ b/app/auth.ts
@@ -1,0 +1,20 @@
+import { auth } from "./util/firebase";
+
+export const authenticate = async (
+  req: Request,
+  res: Response,
+  next: Function
+) => {
+  try {
+    const header = req.headers.get("Authentication");
+    if (!header) throw "invalid header";
+
+    const [authType, authToken] = header.split(" ");
+    if (authType !== "Bearer") throw "invalid auth type";
+
+    req.authInfo = await auth.verifyIdToken(authToken);
+    next();
+  } catch (e) {
+    return { error: "Not Authorized" };
+  }
+};

--- a/app/handlers/orgHandler.ts
+++ b/app/handlers/orgHandler.ts
@@ -38,6 +38,6 @@ export const updateOrg = async (
   res: Response
 ): Promise<any> => {
   let request = req.body as UpdateOrgRequest;
-  const orgRef = db.collection("organizations").doc();
+  const orgRef = db.collection("organizations").doc(req.params.orgID);
   return await orgRef.update(request);
 };

--- a/app/handlers/orgHandler.ts
+++ b/app/handlers/orgHandler.ts
@@ -24,7 +24,7 @@ export const createOrg = async (
       return { orgId : orgRef.id };
     }).catch(
     async error => {
-      return { error : error };
+     return { error : error} ;
     });
 };
 

--- a/app/handlers/orgHandler.ts
+++ b/app/handlers/orgHandler.ts
@@ -24,7 +24,7 @@ export const createOrg = async (
       return { orgId : orgRef.id };
     }).catch(
     async error => {
-     return { error : error };
+      return { error : error };
     });
 };
 

--- a/app/handlers/userHandler.ts
+++ b/app/handlers/userHandler.ts
@@ -1,59 +1,88 @@
 // This file contains the firebase implementations of the endpoints.
 
-
 import { Request, Response } from "express-serve-static-core";
 import { firestore } from "firebase";
-import { Event, Org, UserInfo } from "../types"
-import { EventRequest, CreateUserRequest, GetUserRequest, DeleteUserRequest } from "../requestTypes";
-import { v4 as uuid } from 'uuid';
+import admin from "firebase-admin";
+import { Event, Org, UserInfo } from "../types";
+import {
+  EventRequest,
+  CreateUserRequest,
+  GetUserRequest,
+  DeleteUserRequest,
+} from "../requestTypes";
+import { v4 as uuid } from "uuid";
 import { materialize } from "../util/commonOps";
-import { auth } from '../util/firebase';
+import { auth } from "../util/firebase";
 
-export async function createUser(db: firestore.Firestore, req: Request, res: Response): Promise<any> {
-  let request = req.body as CreateUserRequest;
-  let id = request.email.toLowerCase();
-  let user: UserInfo = {
-    tags: request.tags || []
+const email = (info?: admin.auth.DecodedIdToken) => {
+  return info?.email?.toLowerCase();
+};
+
+export async function createUser(
+  db: firestore.Firestore,
+  req: Request,
+  res: Response
+): Promise<any> {
+  const request = req.body as CreateUserRequest;
+  const user: UserInfo = {
+    tags: request.tags || [],
   };
-  let userRef: firestore.DocumentReference = db.collection('users').doc(id);
-  return userRef.get().then(
-    async doc => {
-      let userDoc = doc;
-      if (userDoc.exists) {
-        return { error: "User already exists!" };
-      } else {
-        return userRef.set(user).then((val) => {
-          return "User successfully created!";
-        });
-      }
+  const id = request.email.toLowerCase();
+  if(id !== email(req.authInfo)) {
+    return "Invalid authentication."
+  }
+  const userRef: firestore.DocumentReference = db.collection("users").doc(id);
+  return userRef.get().then(async (userDoc) => {
+    if (userDoc.exists) {
+      return { error: "User already exists!" };
+    } else {
+      return userRef.set(user).then((val) => {
+        return "User successfully created!";
+      });
     }
-  );
+  });
 }
 
-export async function getUser(db: firestore.Firestore, req: Request, res: Response): Promise<any> {
+export async function getUser(
+  db: firestore.Firestore,
+  req: Request,
+  res: Response
+): Promise<any> {
   let request = req.body as GetUserRequest;
   let id = request.email.toLowerCase();
-  let userDocRef = db.collection('users').doc(id);
-  return auth.getUserByEmail(id)
+  let userDocRef = db.collection("users").doc(id);
+  return auth
+    .getUserByEmail(id)
     .then(async ({ uid, email, displayName, photoURL }) => {
       const doc = await userDocRef.get();
       if (!doc.exists) {
         throw `User with email: ${id} not found!`;
       }
       return {
-        uid, email, displayName, photoURL, ...await materialize(doc.data())
+        uid,
+        email,
+        displayName,
+        photoURL,
+        ...(await materialize(doc.data())),
       };
     })
     .catch((error) => {
-      console.log('Error fetching user data:', error);
+      console.log("Error fetching user data:", error);
       return { error: error };
     });
 }
 
-export async function deleteUser(db: firestore.Firestore, req: Request, res: Response): Promise<any> {
+export async function deleteUser(
+  db: firestore.Firestore,
+  req: Request,
+  res: Response
+): Promise<any> {
   let request = req.body as DeleteUserRequest;
   let id = request.email.toLowerCase();
-  let userDocRef = db.collection('users').doc(id);
+  if(id !== email(req.authInfo)) {
+    return "Invalid authentication."
+  }
+  let userDocRef = db.collection("users").doc(id);
   return userDocRef.delete().then((val) => {
     return { deleted: true };
   });

--- a/app/test/tests/eventHandlerTest.ts
+++ b/app/test/tests/eventHandlerTest.ts
@@ -49,7 +49,7 @@ export async function runCreateTest(db: firestore.Firestore) {
 // Get Event Test
 export async function runGetTest(db: firestore.Firestore) {
   let mockBody: GetEventRequest = {
-    eventId: "event"
+    eventId: "event-1"
   };
 
   let mockRequest = new MockExpressRequest({

--- a/app/test/tests/userHandlerTest.ts
+++ b/app/test/tests/userHandlerTest.ts
@@ -20,7 +20,10 @@ export async function runDeleteTest(db: firestore.Firestore) {
   let mockRequest = new MockExpressRequest({
     method: "POST",
     url: "/deleteUser/",
-    body: mockBody
+    body: mockBody,
+    authInfo: {
+      email: "sirenochen@gmail.com"
+    }
   });
   let mockResponse = new MockExpressResponse();
   let preDoc = db.collection("users").doc("sirenochen@gmail.com");
@@ -60,7 +63,10 @@ export async function runCreateTest(db: firestore.Firestore) {
   let mockRequest = new MockExpressRequest({
     method: "POST",
     url: "/createUser/",
-    body: mockBody
+    body: mockBody,
+    authInfo: {
+      email: "sirenochen@gmail.com"
+    }
   });
   let mockResponse = new MockExpressResponse();
   let preDoc = db.collection("users").doc("sirenochen@gmail.com");
@@ -98,7 +104,10 @@ export async function runGetTest(db: firestore.Firestore) {
   let mockRequest = new MockExpressRequest({
     method: "GET",
     url: "/getUser/",
-    body: mockBody
+    body: mockBody,
+    authInfo: {
+      email: "sirenochen@gmail.com"
+    }
   });
   let mockResponse = new MockExpressResponse();
   let preDoc = db.collection("users").doc("sirenochen@gmail.com");

--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
   "devDependencies": {},
   "engines": {
     "node": "12.x"
-  }
+  },
+  "files":["types.d.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "installAll": "npm i && cd test-suite-app/test-suite-app/ && npm i",
     "test": "concurrently \"ts-node app/test/runTests.ts ui\" \"cd test-suite-app/test-suite-app/ && npm start\"",
-    "terminalTest": "ts-node app/test/runTests.ts log",
+    "terminalTest": "ts-node --files app/test/runTests.ts log",
     "tsc": "tsc",
-    "start": "ts-node app/app.ts > logs.txt"
+    "start": "ts-node --files app/app.ts > logs.txt"
   },
   "repository": {
     "type": "git",
@@ -52,6 +52,5 @@
   "devDependencies": {},
   "engines": {
     "node": "12.x"
-  },
-  "files":["types.d.ts"]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,7 @@
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    "typeRoots": ["/"],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,8 @@
+import admin from "firebase-admin";
+
+declare global {
+  export interface Request {
+    authInfo: admin.auth.DecodedIdToken;
+  }
+  export interface Response {}
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,8 +1,8 @@
 import admin from "firebase-admin";
 
-declare global {
+declare module "express-serve-static-core" {
   export interface Request {
-    authInfo: admin.auth.DecodedIdToken;
+    authInfo ?: admin.auth.DecodedIdToken;
   }
   export interface Response {}
 }


### PR DESCRIPTION
### Summary

This extends the Express `req` object/type with a field `authInfo` containing firebase authentication info.

It's up to each endpoint handler function to check `req.authInfo` if necessary. The field will be falsy if there was no valid authentication provided.

`authInfo` is of type [DecodedIdToken](https://firebase.google.com/docs/reference/admin/node/admin.auth.DecodedIdToken), which has fields like `email`.
This PR doesn't include a check for cornell.edu emails.

#### Client Usage
Authentication is provided by the client through the headers, in the format:
`Authentication: Bearer [id]`
![image](https://user-images.githubusercontent.com/3837473/80873429-77b3cd80-8c86-11ea-8bbe-b21cb8433046.png)

The `id` would be a Firebase Auth ID token JWT string, which clients get through the Firebase Sign-in API.

### Testing

Tested with Postman with both valid and invalid tokens